### PR TITLE
fix(dodgy): prevent doble fee on `to_string`

### DIFF
--- a/types/dodgy/dodgy.mojo
+++ b/types/dodgy/dodgy.mojo
@@ -1,3 +1,6 @@
+from memory import memcpy
+
+
 @value
 @register_passable("trivial")
 struct DodgyString:
@@ -13,5 +16,8 @@ struct DodgyString:
         return DodgyString(p, l)
 
     fn to_string(self) -> String:
-        let s = String(self.data, self.len)
-        return s
+        let ptr = Pointer[Int8]().alloc(self.len)
+
+        memcpy(ptr, self.data, self.len)
+
+        return String(ptr, self.len)


### PR DESCRIPTION
Was getting this when using the previous code:

```
free(): double free detected in tcache 2
Please submit a bug report to https://github.com/modularml/mojo/issues and include the crash backtrace along with all the relevant source codes.
Stack dump:
0.	Program arguments: mojo run test.mojo
 #0 0x00005650fb272797 (/home/igor/.modular/pkg/packages.modular.com_mojo/bin/mojo+0x5bc797)
 #1 0x00005650fb27036e (/home/igor/.modular/pkg/packages.modular.com_mojo/bin/mojo+0x5ba36e)
 #2 0x00005650fb272e6f (/home/igor/.modular/pkg/packages.modular.com_mojo/bin/mojo+0x5bce6f)
 #3 0x00007f2c80642520 (/lib/x86_64-linux-gnu/libc.so.6+0x42520)
 #4 0x00007f2c80696a7c pthread_kill (/lib/x86_64-linux-gnu/libc.so.6+0x96a7c)
 #5 0x00007f2c80642476 gsignal (/lib/x86_64-linux-gnu/libc.so.6+0x42476)
 #6 0x00007f2c806287f3 abort (/lib/x86_64-linux-gnu/libc.so.6+0x287f3)
 #7 0x00007f2c806896f6 (/lib/x86_64-linux-gnu/libc.so.6+0x896f6)
 #8 0x00007f2c806a0d7c (/lib/x86_64-linux-gnu/libc.so.6+0xa0d7c)
 #9 0x00007f2c806a312b (/lib/x86_64-linux-gnu/libc.so.6+0xa312b)
#10 0x00007f2c806a54d3 __libc_free (/lib/x86_64-linux-gnu/libc.so.6+0xa54d3)
#11 0x00007f2be8004906 
make: *** [Makefile:18: test] Aborted (core dumped)
zsh returned exit code 2
```